### PR TITLE
README: Add extra run instructions for running without V in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PRs are welcome. Please prefix your PR titles with the component you are editing
 ```
 ./v -prod json2v -o json2v/json2v
 ```
-3. Run ```py2v.sh``` normally
+3. Run ```./py2v.sh``` to run.  
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ cd py2v
 
 PRs are welcome. Please prefix your PR titles with the component you are editing. (`docs: improve README.md` etc.)
 
+## Running without V in PATH
+1. Build V then put it and all required folders to run V in directory. (cmd, 3rdparty, vlib)  
+
+2. Add  ```./``` before v in ```py2v.sh```:  
+```
+right here
+V
+ v -prod json2v -o json2v/json2v
+```
+3. Run ```py2v.sh``` normally
+
 ## License
 
 [MIT License](/LICENSE)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd py2v
 PRs are welcome. Please prefix your PR titles with the component you are editing. (`docs: improve README.md` etc.)
 
 ## Running without V in PATH
-1. Build V then put it and all required folders to run V in directory. (cmd, 3rdparty, vlib)  
+1. Build V then put it and all required folders to run V in directory. (```cmd```, ```3rdparty```, ```vlib```)  
 
 2. Add  ```./``` before v in ```py2v.sh```:  
 ```

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ PRs are welcome. Please prefix your PR titles with the component you are editing
 
 2. Add  ```./``` before v in ```py2v.sh```:  
 ```
-right here
-V
- v -prod json2v -o json2v/json2v
+./v -prod json2v -o json2v/json2v
 ```
 3. Run ```py2v.sh``` normally
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Dependencies:
 git clone https://github.com/vlang/py2v.git
 cd py2v
 
-# only use next command if you don't have V on PATH
-./v -prod json2v -o json2v/json2v
+# only needed if you don't have V on PATH
+<path to V> -prod json2v -o json2v/json2v
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Dependencies:
 ```bash
 git clone https://github.com/vlang/py2v.git
 cd py2v
+
+# only use next command if you don't have V on PATH
+./v -prod json2v -o json2v/json2v
 ```
 
 ## Usage
@@ -24,15 +27,6 @@ cd py2v
 ## Contributing
 
 PRs are welcome. Please prefix your PR titles with the component you are editing. (`docs: improve README.md` etc.)
-
-## Running without V in PATH
-1. Build V then put it and all required folders to run V in directory. (```cmd```, ```3rdparty```, ```vlib```)  
-
-2. Add  ```./``` before v in ```py2v.sh```:  
-```
-./v -prod json2v -o json2v/json2v
-```
-3. Run ```./py2v.sh``` to run.  
 
 ## License
 


### PR DESCRIPTION
A lot of people use V as an executable so this pull request adds instructions to run py2v that way.