### PR TITLE
Fix parser warnings from JSON decode/map indexing

### DIFF
--- a/parser.v
+++ b/parser.v
@@ -1255,9 +1255,11 @@ fn parse_dict_comp(m map[string]json2.Any) DictComp {
 		key:        parse_expr(map_field(m, 'key')) or { Expr(Constant{
 			value: NoneValue{}
 		}) }
-		value:      parse_expr(map_field(m, 'value')) or { Expr(Constant{
-			value: NoneValue{}
-		}) }
+		value:      parse_expr(map_field(m, 'value')) or {
+			Expr(Constant{
+				value: NoneValue{}
+			})
+		}
 		generators: generators
 		loc:        parse_location(m)
 	}
@@ -1290,9 +1292,11 @@ fn parse_comprehension(m map[string]json2.Any) Comprehension {
 		}
 	}
 	return Comprehension{
-		target:   parse_expr(map_field(m, 'target')) or { Expr(Constant{
-			value: NoneValue{}
-		}) }
+		target:   parse_expr(map_field(m, 'target')) or {
+			Expr(Constant{
+				value: NoneValue{}
+			})
+		}
 		iter:     parse_expr(map_field(m, 'iter')) or { Expr(Constant{
 			value: NoneValue{}
 		}) }


### PR DESCRIPTION
## Summary
  - Replace deprecated json2.raw_decode with json2.decode[json2.Any]
  - Add safe map_field helper for nested JSON map access
  - Remove parser warning-prone map indexing patterns
  - vfmt parser.v

  ## Validation
  - v . -o py2v
  - v test .
  - bash tests/run_tests.sh