### PR TITLE
 Class-Level Variable Assignments

### DIFF
--- a/ast.v
+++ b/ast.v
@@ -456,6 +456,7 @@ pub mut:
 	decorator_list    []Expr
 	loc               Location
 	declarations      map[string]string
+	class_defaults    map[string]Expr
 	docstring_comment ?string
 }
 

--- a/parser.v
+++ b/parser.v
@@ -328,6 +328,15 @@ fn parse_class_def(m map[string]json2.Any) ClassDef {
 			declarations[key] = val.str()
 		}
 	}
+	mut class_defaults := map[string]Expr{}
+	if raw_defaults := m['class_defaults'] {
+		raw_map := raw_defaults.as_map()
+		for key, val in raw_map {
+			if expr := parse_expr(val.as_map()) {
+				class_defaults[key] = expr
+			}
+		}
+	}
 	mut docstring := ?string(none)
 	if raw_doc := m['docstring_comment'] {
 		s := raw_doc.str()
@@ -343,6 +352,7 @@ fn parse_class_def(m map[string]json2.Any) ClassDef {
 		decorator_list:    decorators
 		loc:               parse_location(m)
 		declarations:      declarations
+		class_defaults:    class_defaults
 		docstring_comment: docstring
 	}
 }

--- a/tests/cases/class_vars.py
+++ b/tests/cases/class_vars.py
@@ -1,0 +1,21 @@
+class Config:
+    """Config holds application settings."""
+
+    debug = False
+    max_retries = 3
+    name = "default"
+    ratio = 0.5
+
+
+class ProxyType:
+    DIRECT = 0
+    MANUAL = 1
+
+
+if __name__ == "__main__":
+    c = Config()
+    print(c.debug)
+    print(c.max_retries)
+    print(c.name)
+    print(c.ratio)
+    print(ProxyType.DIRECT)

--- a/tests/expected/builtin_name_escape.v
+++ b/tests/expected/builtin_name_escape.v
@@ -5,7 +5,7 @@ type Any = bool | int | i64 | f64 | string | []byte
 
 fn make_pair(@string Any, @int Any) map[string]Any {
 	return {
-		'name': @string
+		'name':  @string
 		'value': @int
 	}
 }

--- a/tests/expected/class_vars.v
+++ b/tests/expected/class_vars.v
@@ -1,0 +1,26 @@
+@[translated]
+module main
+
+// Config holds application settings.
+pub struct Config {
+pub mut:
+	debug       bool   = false
+	max_retries int    = 3
+	name        string = 'default'
+	ratio       f64    = 0.5
+}
+
+const proxy_type_direct = 0
+const proxy_type_manual = 1
+
+pub struct ProxyType {
+}
+
+fn main() {
+	c := Config{}
+	println((c.debug).str())
+	println((c.max_retries).str())
+	println((c.name).str())
+	println((c.ratio).str())
+	println(proxy_type_direct.str())
+}

--- a/tests/expected/fib_with_argparse.v
+++ b/tests/expected/fib_with_argparse.v
@@ -3,8 +3,8 @@ module main
 
 pub struct Options {
 pub mut:
-	v bool
-	n int
+	v bool = false
+	n int  = 0
 }
 
 fn fib(i int) int {

--- a/tests/expected/int_enum.v
+++ b/tests/expected/int_enum.v
@@ -1,26 +1,34 @@
 @[translated]
 module main
 
+const colors_red = auto()
+const colors_green = auto()
+const colors_blue = auto()
+
 pub struct Colors {
 }
+
+const permissions_r = 1
+const permissions_w = 2
+const permissions_x = 16
 
 pub struct Permissions {
 }
 
 fn show() {
 	color_map := {
-		Colors.RED:   'red'
-		Colors.GREEN: 'green'
-		Colors.BLUE:  'blue'
+		colors_red:   'red'
+		colors_green: 'green'
+		colors_blue:  'blue'
 	}
-	a := Colors.GREEN
-	if a == Colors.GREEN {
+	a := colors_green
+	if a == colors_green {
 		println('green')
 	} else {
 		println('Not green')
 	}
-	b := Permissions.R
-	if b == Permissions.R {
+	b := permissions_r
+	if b == permissions_r {
 		println('R')
 	} else {
 		println('Not R')

--- a/tests/expected/str_enum.v
+++ b/tests/expected/str_enum.v
@@ -1,17 +1,21 @@
 @[translated]
 module main
 
+const colors_red = 'red'
+const colors_green = 'green'
+const colors_blue = 'blue'
+
 pub struct Colors {
 }
 
 fn show() {
 	color_map := {
-		Colors.RED:   '1'
-		Colors.GREEN: '2'
-		Colors.BLUE:  '3'
+		colors_red:   '1'
+		colors_green: '2'
+		colors_blue:  '3'
 	}
-	a := Colors.GREEN
-	if a == Colors.GREEN {
+	a := colors_green
+	if a == colors_green {
 		println('green')
 	} else {
 		println('Not green')


### PR DESCRIPTION
## Supports Python class-level variable assignments (e.g. debug = False, DIRECT = 0) in transpiled V output.

- Simple literals (bool, int, float, string) → V struct field defaults (field type = value)
- Complex expressions → module-level const symbols
- Uppercase Python attrs (e.g. DIRECT, MANUAL) → snake_case module-level const (e.g. proxy_type_direct)
- Attribute resolution: ClassName.ATTR references are resolved to the module-level `const` symbol

### Files changed:

- frontend/ast_dump.py — _infer_type_from_value(), _extract_class_defaults(), bare Assign handling
- ast.v — added class_defaults map[string]Expr on ClassDef
- parser.v — parses class_defaults
- transpiler.v — is_simple_default(), to_symbol_ident(), is_v_field_ident(), class_attr_symbol_name(), attribute symbol resolution in visit_attribute()
- tests/cases/class_vars.py, tests/expected/class_vars.v — new test case
- tests/expected/int_enum.v, tests/expected/str_enum.v, tests/expected/fib_with_argparse.v — updated expected outputs
### Other
- agents.md — added rules for pre-commit v fmt and Linux testing