### PR TITLE
use defer for finally blocks and with-statement file cleanup

### DIFF
--- a/tests/cases/defer_finally.py
+++ b/tests/cases/defer_finally.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+
+def pure_finally() -> int:
+    """try/finally without except should produce clean defer."""
+    result = 0
+    try:
+        result = 42
+    finally:
+        print("cleanup")
+    return result
+
+
+def nested_finally() -> int:
+    """Nested try/finally blocks each get their own defer."""
+    try:
+        try:
+            x = 10
+        finally:
+            print("inner cleanup")
+    finally:
+        print("outer cleanup")
+    return x
+
+
+def mixed_handlers():
+    """try/except/finally should defer the finally and comment the except."""
+    try:
+        value = int("123")
+        print(value)
+    except ValueError as e:
+        print("bad value")
+    finally:
+        print("done")
+
+
+def multi_stmt_finally():
+    """Multiple statements in finally all go inside a single defer block."""
+    resource = None
+    try:
+        resource = 1
+    finally:
+        print("step 1")
+        print("step 2")
+        resource = None
+
+
+if __name__ == "__main__":
+    print(pure_finally())
+    print(nested_finally())
+    mixed_handlers()
+    multi_stmt_finally()

--- a/tests/cases/with_file_cleanup.py
+++ b/tests/cases/with_file_cleanup.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+
+
+def write_and_read():
+    """File handles in with statements should get defer close."""
+    path = tempfile.mktemp()
+    with open(path, "w") as f:
+        f.write("hello world")
+
+    with open(path, "r") as f:
+        data = f.read()
+        print(data)
+
+    os.remove(path)
+
+
+def nested_files():
+    """Nested with-open blocks each get their own defer."""
+    path1 = "a.txt"
+    path2 = "b.txt"
+    with open(path1, "w") as f1:
+        f1.write("file1")
+        with open(path2, "w") as f2:
+            f2.write("file2")
+
+
+if __name__ == "__main__":
+    write_and_read()
+    nested_files()

--- a/tests/expected/defer_finally.v
+++ b/tests/expected/defer_finally.v
@@ -1,0 +1,53 @@
+@[translated]
+module main
+
+fn pure_finally() int {
+	mut result := 0
+	defer {
+		println('cleanup')
+	}
+	result = 42
+	return result
+}
+
+fn nested_finally() int {
+	defer {
+		println('outer cleanup')
+	}
+	defer {
+		println('inner cleanup')
+	}
+	x := 10
+	return x
+}
+
+fn mixed_handlers() {
+	defer {
+		println('done')
+	}
+	// try {
+	value := '123'.int()
+	println(value.str())
+	// } catch {
+	// except ValueError:
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
+	// println('bad value')
+	// }
+}
+
+fn multi_stmt_finally() {
+	mut resource := none
+	defer {
+		println('step 1')
+		println('step 2')
+		resource = none
+	}
+	resource = 1
+}
+
+fn main() {
+	println((pure_finally()).str())
+	println((nested_finally()).str())
+	mixed_handlers()
+	multi_stmt_finally()
+}

--- a/tests/expected/exception_names.v
+++ b/tests/expected/exception_names.v
@@ -6,7 +6,7 @@ fn show() {
 	(3 / 0)
 	// } catch {
 	// except ZeroDivisionError:
-	// NOTE: V does not have exception handling - this code is unreachable
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
 	// println('ZeroDivisionError')
 	// }
 }

--- a/tests/expected/exceptions.v
+++ b/tests/expected/exceptions.v
@@ -2,27 +2,28 @@
 module main
 
 fn show() {
+	defer {
+		println('Finally')
+	}
 	// try {
 	panic('Exception: ' + 'foo')
 	// } catch {
 	// except Exception:
-	// NOTE: V does not have exception handling - this code is unreachable
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
 	// println('caught')
-	// finally:
-	println('Finally')
 	// }
 	// try {
 	panic('Exception: ' + 'foo')
 	// } catch {
 	// except:
-	// NOTE: V does not have exception handling - this code is unreachable
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
 	// println('Got it')
 	// }
 	// try {
 	panic('Exception: ' + 'foo')
 	// } catch {
 	// except Exception:
-	// NOTE: V does not have exception handling - this code is unreachable
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
 	// assert e.str().contains('foo')
 	// }
 }

--- a/tests/expected/try_finally.v
+++ b/tests/expected/try_finally.v
@@ -3,27 +3,26 @@ module main
 
 fn with_finally(x int) int {
 	mut result := 0
-	// try {
+	defer {
+		println('finally executed')
+	}
 	result = (x * 2)
-	// } catch {
-	// finally:
-	println('finally executed')
-	// }
 	return result
 }
 
 fn main_func() {
 	println((with_finally(5)).str())
 	println((with_finally(10)).str())
+	defer {
+		println('cleanup')
+	}
 	// try {
 	x := 10
 	println(x.str())
 	// } catch {
 	// except:
-	// NOTE: V does not have exception handling - this code is unreachable
+	// NOTE: V uses Result types (!) and or{} blocks instead of exceptions
 	// println('error')
-	// finally:
-	println('cleanup')
 	// }
 }
 

--- a/tests/expected/with_file_cleanup.v
+++ b/tests/expected/with_file_cleanup.v
@@ -1,0 +1,42 @@
+@[translated]
+module main
+
+import os
+
+fn write_and_read() {
+	path := tempfile.mktemp()
+	if true {
+		mut f := os.create(path) or { panic(err) }
+		defer { f.close() }
+		f.write('hello world')
+	}
+
+	if true {
+		mut f := os.open(path) or { panic(err) }
+		defer { f.close() }
+		data := f.read()
+		println(data.str())
+	}
+
+	os.delete(os.index(path))
+}
+
+fn nested_files() {
+	path1 := 'a.txt'
+	path2 := 'b.txt'
+	if true {
+		mut f1 := os.create(path1) or { panic(err) }
+		defer { f1.close() }
+		f1.write('file1')
+		if true {
+			mut f2 := os.create(path2) or { panic(err) }
+			defer { f2.close() }
+			f2.write('file2')
+		}
+	}
+}
+
+fn main() {
+	write_and_read()
+	nested_files()
+}

--- a/tests/expected/with_open.v
+++ b/tests/expected/with_open.v
@@ -9,11 +9,13 @@ fn main() {
 		file_path := temp_file.name
 		if true {
 			mut f := os.create(file_path) or { panic(err) }
+			defer { f.close() }
 			f.write('hello')
 		}
 
 		if true {
 			mut f := os.open(file_path) or { panic(err) }
+			defer { f.close() }
 			assert f.read(1) == 'h'
 			assert f.read() == 'ello'
 			println('OK')


### PR DESCRIPTION
Converts Python `finally` blocks to V's `defer {}` for correct cleanup semantics,
and adds automatic `defer { f.close() }` for file handles in `with` statements.

### Changes

- **`visit_try()`**: `finally` blocks now emit `defer { }` before the try body instead of running inline. Pure `try/finally` (no `except`) produces clean output without comment noise.
- **`visit_with()`**: File handles opened via `open()`, `os.create()`, or `os.open()` in `with` blocks now get `defer { target.close() }` for automatic cleanup.
- 4 existing test expected outputs updated to match new behavior
- 2 new test case pairs added (`defer_finally`, `with_file_cleanup`)

All 107 tests pass.

Partially addresses #5.