### PR TITLE
expand isinstance for tuple of types

### DIFF
--- a/plugins.v
+++ b/plugins.v
@@ -386,6 +386,22 @@ fn visit_id(args []string) (string, bool) {
 
 // Handle isinstance() call
 fn visit_isinstance(args []string) (string, bool) {
+	types_arg := args[1]
+	// Handle tuple of types: isinstance(x, (A, B)) → x is A || x is B
+	// visit_tuple renders Python tuples as V arrays: [A, B, ...]
+	if types_arg.starts_with('[') && types_arg.ends_with(']') {
+		inner := types_arg[1..types_arg.len - 1]
+		types := inner.split(', ')
+		if types.len > 1 {
+			mut parts := []string{}
+			for typ in types {
+				parts << '${args[0]} is ${typ}'
+			}
+			return '(${parts.join(' || ')})', true
+		}
+		// Single-element tuple: isinstance(x, (A,)) → x is A
+		return '${args[0]} is ${types[0]}', true
+	}
 	return '${args[0]} is ${args[1]}', true
 }
 

--- a/tests/cases/isinstance_types.py
+++ b/tests/cases/isinstance_types.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+
+class Animal:
+    pass
+
+
+class Dog(Animal):
+    pass
+
+
+class Cat(Animal):
+    pass
+
+
+class Bird(Animal):
+    pass
+
+
+def check_single(x) -> bool:
+    """Single type isinstance."""
+    return isinstance(x, Dog)
+
+
+def check_tuple(x) -> bool:
+    """Tuple of types isinstance."""
+    return isinstance(x, (Dog, Cat))
+
+
+def check_triple(x) -> bool:
+    """Three types isinstance."""
+    return isinstance(x, (Dog, Cat, Bird))
+
+
+def check_in_if(x):
+    """isinstance in if condition."""
+    if isinstance(x, (Dog, Cat)):
+        print("pet")
+    else:
+        print("other")
+
+
+def check_negated(x) -> bool:
+    """Negated isinstance with tuple."""
+    return not isinstance(x, (Dog, Cat))
+
+
+if __name__ == "__main__":
+    d = Dog()
+    print(check_single(d))
+    print(check_tuple(d))
+    print(check_triple(d))
+    check_in_if(d)
+    print(check_negated(d))

--- a/tests/expected/isinstance_types.v
+++ b/tests/expected/isinstance_types.v
@@ -1,0 +1,52 @@
+@[translated]
+module main
+
+type Any = bool | int | i64 | f64 | string | []byte
+
+pub struct Animal {
+}
+
+pub struct Dog {
+	Animal
+}
+
+pub struct Cat {
+	Animal
+}
+
+pub struct Bird {
+	Animal
+}
+
+fn check_single(x Any) bool {
+	return x is Dog
+}
+
+fn check_tuple(x Any) bool {
+	return x is Dog || x is Cat
+}
+
+fn check_triple(x Any) bool {
+	return x is Dog || x is Cat || x is Bird
+}
+
+fn check_in_if(x Any) {
+	if (x is Dog || x is Cat) {
+		println('pet')
+	} else {
+		println('other')
+	}
+}
+
+fn check_negated(x Any) bool {
+	return !(x is Dog || x is Cat)
+}
+
+fn main() {
+	d := Dog{}
+	println(if check_single(d) { 'True' } else { 'False' })
+	println(if check_tuple(d) { 'True' } else { 'False' })
+	println(if check_triple(d) { 'True' } else { 'False' })
+	check_in_if(d)
+	println(if check_negated(d) { 'True' } else { 'False' })
+}


### PR DESCRIPTION
Expands `isinstance()` handling to support the tuple-of-types form.

Previously, `isinstance(x, (TypeA, TypeB))` produced invalid V (`x is [TypeA, TypeB]`)
because the tuple was rendered as an array literal. Now correctly expands to
`(x is TypeA || x is TypeB)`.

Single-type `isinstance(x, Foo)` is unchanged.

### Changes

- **`visit_isinstance()`** in `plugins.v`: detect `[...]` tuple pattern, expand to `x is A || x is B || ...`
- 1 new test case pair (`isinstance_types`) covering single type, 2-type tuple, 3-type tuple, tuple in if-condition, and negated tuple

All 108 tests pass.

Partially addresses #5.