### PR TITLE
convert logging calls to v log module

### DIFF
--- a/tests/cases/logging_calls.py
+++ b/tests/cases/logging_calls.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import logging
+
+
+def process():
+    logging.basicConfig()
+    logging.info("starting")
+    logging.debug("x=42")
+    logging.warning("low memory")
+    logging.warn("also a warning")
+    logging.error("failed")
+    logging.critical("shutdown")
+    logging.exception("caught error")
+
+
+if __name__ == "__main__":
+    process()

--- a/tests/expected/logging_calls.v
+++ b/tests/expected/logging_calls.v
@@ -1,0 +1,18 @@
+@[translated]
+module main
+
+import log
+
+fn process() {
+	log.info('starting')
+	log.debug('x=42')
+	log.warn('low memory')
+	log.warn('also a warning')
+	log.error('failed')
+	log.error('shutdown')
+	log.error('caught error')
+}
+
+fn main() {
+	process()
+}


### PR DESCRIPTION
Converts Python `logging` module calls to V's `log` module.

### Changes

- **`visit_logging()`** in `plugins.v`: maps Python logging levels to V's `log` module
  - `debug`/`info`/`error` map directly
  - `warning` → `warn` (V naming)
  - `critical`/`exception` → `error` (V's `fatal` panics, so `error` is the safe equivalent)
- Setup calls (`basicConfig`, `getLogger`) are suppressed — no V equivalent
- `import log` is injected automatically when any logging call is translated
- 1 new test case covering all 7 call variants plus `basicConfig` suppression

All 109 tests pass.