### PR TITLE
use math.powi/pow for power operator instead of bitwise xor

### DIFF
--- a/tests/cases/numeric_ops.py
+++ b/tests/cases/numeric_ops.py
@@ -11,6 +11,15 @@ def main():
     print(2 ** 10)
     print(3 ** 4)
 
+    # Negative exponent (Python auto-promotes to float)
+    print(2 ** -1)
+    print(10 ** -2)
+
+    # Power augmented assignment
+    b = 2
+    b **= 3
+    print(b)
+
     # Combined
     a = 100
     print(a // 7)

--- a/tests/expected/math_func.v
+++ b/tests/expected/math_func.v
@@ -1,8 +1,10 @@
 @[translated]
 module main
 
+import math
+
 fn main_func() {
-	a := 2 ^ 4
+	a := math.powi(2, 4)
 	println(a.str())
 }
 

--- a/tests/expected/numeric_ops.v
+++ b/tests/expected/numeric_ops.v
@@ -8,12 +8,17 @@ fn main_func() {
 	println((math.divide_floored(-17, 5).quot).str())
 	println((17 % 5).str())
 	println((-17 % 5).str())
-	println((2 ^ 10).str())
-	println((3 ^ 4).str())
+	println((math.powi(2, 10)).str())
+	println((math.powi(3, 4)).str())
+	println((math.pow(2, -1)).str())
+	println((math.pow(10, -2)).str())
+	mut b := 2
+	b = math.powi(b, 3)
+	println(b.str())
 	a := 100
 	println((math.divide_floored(a, 7).quot).str())
 	println((a % 7).str())
-	println((a ^ 2).str())
+	println((math.powi(a, 2)).str())
 	mut c := -7
 	c = math.divide_floored(c, 2).quot
 	println(c.str())

--- a/types.v
+++ b/types.v
@@ -147,7 +147,7 @@ pub fn op_to_symbol(op_type string) string {
 		'Div' { '/' }
 		'FloorDiv' { '/' } // Not floor division in V, handled in visit_binop/visit_aug_assign
 		'Mod' { '%' }
-		'Pow' { '^' } // Note: V uses ^ for power, not **
+		'Pow' { '**' } // Not a V operator, handled in visit_binop/visit_aug_assign
 		'LShift' { '<<' }
 		'RShift' { '>>' }
 		'BitOr' { '|' }


### PR DESCRIPTION
Python's `**` operator was mapped to V's `^` which is bitwise XOR, not exponentiation. `2 ** 10` produced `2 ^ 10 = 8` instead of `1024`.

Uses `math.powi()` for integer operands (preserves int type) and `math.pow()` for float operands or negative exponents (Python auto-promotes `2**-1` to `0.5`). Also handles `**=` augmented assignment by expanding to assignment form since V has no `**=` operator.

### Changes

- `visit_binop()` in `transpiler.v`: Pow handler with type-aware dispatch to `math.powi` (int) or `math.pow` (float/negative exponent)
- `visit_aug_assign()` in `transpiler.v`: Pow special-case expands `a **= b` to `a = math.powi(a, b)` or `a = math.pow(a, b)`
- Negative exponent detection: `UnaryOp(USub, ...)` forces float path
- `op_to_symbol()` in `types.v`: Pow maps to `**` (not a V operator)
- Test cases added for `**=` augmented assignment and negative exponents
- 3 test expected outputs updated (numeric_ops, math_func)

All 110 tests pass.

### Known limitations (follow-up)

- `math.powi` returns i64, may need cast in typed contexts
- Variable negative exponents (`x = -1; 2 ** x`) not detected at transpile time