### PR TITLE
use math.divide_floored for floor division to match python semantics

### DIFF
--- a/tests/cases/numeric_ops.py
+++ b/tests/cases/numeric_ops.py
@@ -17,6 +17,11 @@ def main():
     print(a % 7)
     print(a ** 2)
 
+    # Floor division augmented assignment
+    c = -7
+    c //= 2
+    print(c)
+
     # Negative numbers
     print(-5 // 2)
     print(-5 % 2)

--- a/tests/expected/multiple_return.v
+++ b/tests/expected/multiple_return.v
@@ -1,6 +1,8 @@
 @[translated]
 module main
 
+import math
+
 fn get_pair() []int {
 	return [1, 2]
 }
@@ -10,7 +12,7 @@ fn get_triple() []int {
 }
 
 fn divmod_custom(a int, b int) []int {
-	return [(a / b), (a % b)]
+	return [math.divide_floored(a, b).quot, (a % b)]
 }
 
 fn main_func() {

--- a/tests/expected/numeric_ops.v
+++ b/tests/expected/numeric_ops.v
@@ -1,18 +1,23 @@
 @[translated]
 module main
 
+import math
+
 fn main_func() {
-	println((17 / 5).str())
-	println((-17 / 5).str())
+	println((math.divide_floored(17, 5).quot).str())
+	println((math.divide_floored(-17, 5).quot).str())
 	println((17 % 5).str())
 	println((-17 % 5).str())
 	println((2 ^ 10).str())
 	println((3 ^ 4).str())
 	a := 100
-	println((a / 7).str())
+	println((math.divide_floored(a, 7).quot).str())
 	println((a % 7).str())
 	println((a ^ 2).str())
-	println((-5 / 2).str())
+	mut c := -7
+	c = math.divide_floored(c, 2).quot
+	println(c.str())
+	println((math.divide_floored(-5, 2).quot).str())
 	println((-5 % 2).str())
 }
 

--- a/types.v
+++ b/types.v
@@ -145,7 +145,7 @@ pub fn op_to_symbol(op_type string) string {
 		'Sub' { '-' }
 		'Mult' { '*' }
 		'Div' { '/' }
-		'FloorDiv' { '/' }
+		'FloorDiv' { '/' } // Not floor division in V, handled in visit_binop/visit_aug_assign
 		'Mod' { '%' }
 		'Pow' { '^' } // Note: V uses ^ for power, not **
 		'LShift' { '<<' }


### PR DESCRIPTION
Python's `//` (floor division) rounds toward negative infinity, but V's `/` truncates toward zero. They produce different results for negative operands: `-7 // 2 = -4` in Python vs `-7 / 2 = -3` in V.

Uses `math.divide_floored()` from V's stdlib for integer operands (returns floored quotient directly) and `math.floor(left / right)` for float operands.

### Changes

- **`visit_binop()`** in `transpiler.v`: FloorDiv handler with type-aware dispatch to `math.divide_floored(a, b).quot` (int) or `math.floor(a / b)` (float)
- **`visit_aug_assign()`** in `transpiler.v`: FloorDiv handler for `//=` augmented assignment, same dispatch logic
- **`types.v`**: clarifying comment on FloorDiv entry in `op_to_symbol`
- 2 test expected outputs updated (`numeric_ops`, `multiple_return`)
- 1 new test case: `//=` augmented assignment with negative numbers

All 110 tests pass.