### PR TITLE
handle sort(reverse=True) keyword argument

### DIFF
--- a/tests/expected/list_sort.v
+++ b/tests/expected/list_sort.v
@@ -6,7 +6,7 @@ fn main_func() {
 	nums.sort(a < b)
 	println(nums.str())
 	nums2 := [3, 1, 4, 1, 5, 9, 2, 6]
-	nums2.sort(a < b)
+	nums2.sort(a > b)
 	println(nums2.str())
 	original := [5, 2, 8, 1, 9]
 	sorted_list := (fn (a []Any) []Any {

--- a/transpiler.v
+++ b/transpiler.v
@@ -2087,9 +2087,13 @@ pub fn (mut t VTranspiler) visit_call(node Call) string {
 				return '${obj}.reverse()'
 			}
 			'sort' {
-				if vargs.len > 0 {
-					// Python sort with key/reverse - complex to translate
-					return '${obj}.sort(a < b)'
+				// Check for reverse=True keyword argument
+				for kw in node.keywords {
+					if arg := kw.arg {
+						if arg == 'reverse' && t.visit_expr(kw.value) == 'true' {
+							return '${obj}.sort(a > b)'
+						}
+					}
 				}
 				return '${obj}.sort(a < b)'
 			}


### PR DESCRIPTION
Python's `list.sort(reverse=True)` was transpiled to `sort(a < b)`, ignoring the `reverse` keyword entirely. Now checks keyword arguments and uses `sort(a > b)` for descending order.

### Changes

- **`visit_call()`** in `transpiler.v`: Inspect `node.keywords` for `reverse=True`, emit `sort(a > b)` for descending order
- 1 test expected output updated (`list_sort`)

All 108 tests pass.