### PR TITLE
handle round() with ndigits argument

### DIFF
--- a/plugins.v
+++ b/plugins.v
@@ -291,6 +291,9 @@ fn visit_abs(args []string) (string, bool, string) {
 
 // Handle round() call
 fn visit_round(args []string) (string, bool, string) {
+	if args.len >= 2 {
+		return 'math.round_sig(${args[0]}, ${args[1]})', true, 'math'
+	}
 	return 'math.round(${args[0]})', true, 'math'
 }
 

--- a/tests/expected/abs_round.v
+++ b/tests/expected/abs_round.v
@@ -10,8 +10,8 @@ fn main_func() {
 	println((math.round(3.7)).str())
 	println((math.round(3.2)).str())
 	println((math.round(3.5)).str())
-	println((math.round(3.1415900000000003)).str())
-	println((math.round(2.71828)).str())
+	println((math.round_sig(3.1415900000000003, 2)).str())
+	println((math.round_sig(2.71828, 3)).str())
 	println((math.abs(-3.14)).str())
 }
 


### PR DESCRIPTION
Python's `round(x, ndigits)` was dropping the second argument, producing `math.round(x)` instead of preserving decimal-place precision. `round(3.14159, 2)` produced `3.0` instead of `3.14`.

### Changes

- **`visit_round()`** in `plugins.v`: Dispatch on `args.len` — two-argument form uses `math.round_sig(x, ndigits)`, single-argument form is unchanged
- 1 test expected output updated (`abs_round`)

All 108 tests pass (0 skipped).