### PR TITLE
fix string predicate method transpilation

### DIFF
--- a/tests/cases/string_predicates.py
+++ b/tests/cases/string_predicates.py
@@ -1,0 +1,20 @@
+def main():
+    # Character classification predicates
+    print("12345".isdigit())
+    print("hello".isalpha())
+    print("hello123".isalnum())
+    print("   ".isspace())
+
+    # Case predicates
+    print("hello".islower())
+    print("HELLO".isupper())
+    print("Hello World".istitle())
+
+    # False cases
+    print("hello123".isdigit())
+    print("hello123".isalpha())
+    print("hello".isupper())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/expected/string_predicates.v
+++ b/tests/expected/string_predicates.v
@@ -1,0 +1,31 @@
+@[translated]
+module main
+
+fn main_func() {
+	println(('12345'.bytes().all(fn (c u8) bool {
+		return c.is_digit()
+	})).str())
+	println(('hello'.bytes().all(fn (c u8) bool {
+		return c.is_letter()
+	})).str())
+	println(('hello123'.bytes().all(fn (c u8) bool {
+		return c.is_alnum()
+	})).str())
+	println(('   '.bytes().all(fn (c u8) bool {
+		return c.is_space()
+	})).str())
+	println(('hello'.is_lower()).str())
+	println(('HELLO'.is_upper()).str())
+	println(('Hello World'.is_title()).str())
+	println(('hello123'.bytes().all(fn (c u8) bool {
+		return c.is_digit()
+	})).str())
+	println(('hello123'.bytes().all(fn (c u8) bool {
+		return c.is_letter()
+	})).str())
+	println(('hello'.is_upper()).str())
+}
+
+fn main() {
+	main_func()
+}

--- a/transpiler.v
+++ b/transpiler.v
@@ -2034,10 +2034,25 @@ pub fn (mut t VTranspiler) visit_call(node Call) string {
 				return '0'
 			}
 			'isdigit' {
-				return '${obj}.is_digit()'
+				return '${obj}.bytes().all(fn (c u8) bool { return c.is_digit() })'
 			}
 			'isalpha' {
-				return '${obj}.is_alpha()'
+				return '${obj}.bytes().all(fn (c u8) bool { return c.is_letter() })'
+			}
+			'isalnum' {
+				return '${obj}.bytes().all(fn (c u8) bool { return c.is_alnum() })'
+			}
+			'isspace' {
+				return '${obj}.bytes().all(fn (c u8) bool { return c.is_space() })'
+			}
+			'islower' {
+				return '${obj}.is_lower()'
+			}
+			'isupper' {
+				return '${obj}.is_upper()'
+			}
+			'istitle' {
+				return '${obj}.is_title()'
 			}
 			// List methods
 			'remove' {


### PR DESCRIPTION
Fixes 7 Python string predicate methods that were either broken or missing.

### Changes

- **`isdigit`/`isalpha`** in `transpiler.v`: fix incorrect mappings to nonexistent `is_digit()`/`is_alpha()` string methods. V's character classification lives on `u8`, not `string`; the correct pattern is `.bytes().all(fn (c u8) bool { return c.is_digit() })`
- **`isalnum`/`isspace`**: add missing methods using same `bytes().all()` pattern with `is_alnum()`/`is_space()`
- **`islower`/`isupper`/`istitle`**: add missing methods mapping directly to V string methods `is_lower()`/`is_upper()`/`is_title()`
- 1 new test case covering all 7 predicates plus 3 false-case inputs

### Verification

| Python | V output | Runtime match |
|--------|----------|---------------|
| `"12345".isdigit()` = `True` | `.bytes().all(...)` with `c.is_digit()` | `true` |
| `"hello".isalpha()` = `True` | `.bytes().all(...)` with `c.is_letter()` | `true` |
| `"hello123".isalnum()` = `True` | `.bytes().all(...)` with `c.is_alnum()` | `true` |
| `"   ".isspace()` = `True` | `.bytes().all(...)` with `c.is_space()` | `true` |
| `"hello".islower()` = `True` | `.is_lower()` | `true` |
| `"HELLO".isupper()` = `True` | `.is_upper()` | `true` |
| `"Hello World".istitle()` = `True` | `.is_title()` | `true` |
| `"hello123".isdigit()` = `False` | same pattern | `false` |
| `"hello123".isalpha()` = `False` | same pattern | `false` |
| `"hello".isupper()` = `False` | `.is_upper()` | `false` |

All 109 tests pass, 0 fail, 0 skip. V 0.5.0 a9423b5, macOS.