### PR TITLE
convert python % string formatting to v interpolation

### DIFF
--- a/tests/cases/string_format_percent.py
+++ b/tests/cases/string_format_percent.py
@@ -1,0 +1,22 @@
+def main():
+    name = "world"
+    age = 25
+    pi = 3.14159
+
+    print("hello %s" % name)
+    print("name=%s age=%d" % (name, age))
+    print("pi is %.2f" % pi)
+    print("count: %d" % age)
+    print("padded: %05d" % age)
+    print("hex: %x" % 255)
+    print("%s is %d years old and likes %.1f" % (name, age, pi))
+    print("score: %d%%" % 95)
+    print("default float: %f" % pi)
+    print("truncated: %.f" % pi)
+    print("left-pad: %-05d" % age)
+    print(10 % 3)
+    print(17 % 5)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/expected/string_format_percent.v
+++ b/tests/expected/string_format_percent.v
@@ -1,0 +1,25 @@
+@[translated]
+module main
+
+fn main_func() {
+	name := 'world'
+	age := 25
+	pi := 3.1415900000000003
+	println('hello ${name}')
+	println('name=${name} age=${age}')
+	println('pi is ${pi:.2f}')
+	println('count: ${age}')
+	println('padded: ${age:05}')
+	println('hex: ${255:x}')
+	println('${name} is ${age} years old and likes ${pi:.1f}')
+	println('score: ${95}%')
+	println('default float: ${pi:.6f}')
+	println('truncated: ${pi:.0f}')
+	println('left-pad: ${age:-5}')
+	println(((10 % 3)).str())
+	println(((17 % 5)).str())
+}
+
+fn main() {
+	main_func()
+}

--- a/transpiler.v
+++ b/transpiler.v
@@ -1697,6 +1697,26 @@ pub fn (mut t VTranspiler) visit_binop(node BinOp) string {
 		return '${left} ^ ${right}'
 	}
 
+	// Handle Python % string formatting -> V string interpolation
+	if node.op is Mod {
+		if node.left is Constant {
+			c := node.left as Constant
+			if c.value is string {
+				fmt_str := c.value as string
+				mut values := []string{}
+				if node.right is Tuple {
+					tup := node.right as Tuple
+					for elt in tup.elts {
+						values << t.visit_expr(elt)
+					}
+				} else {
+					values << right
+				}
+				return convert_percent_format(fmt_str, values)
+			}
+		}
+	}
+
 	// Handle string/list repetition
 	if node.op is Mult {
 		left_ann := get_expr_annotation(node.left)


### PR DESCRIPTION
Converts Python `%` string formatting expressions to V string interpolation
with correct format specifiers.

### Changes

- **`convert_percent_format()`** in `helpers.v`: parses Python `%` format
  specifiers (`%s`, `%d`, `%f`, `%e`, `%g`, `%x`, `%o`, `%%`) and emits V
  interpolation with correct format specs
  - Preserves Python default precision (6 decimal places for bare `%f`/`%e`)
  - Left-align flag overrides zero-pad (`%-05d` -> `:-5`)
  - Bare dot precision means 0 (`%.f` -> `:.0f`)
- **`visit_binop()`** in `transpiler.v`: detects `Mod` with string `Constant`
  on left side and routes to format conversion instead of raw `%`
  - Integer modulo (`10 % 3`) passes through correctly

### Test plan

- 109 pass, 0 fail, 0 skip (V 0.5.0 a9423b5, macOS)
- New test case `string_format_percent` covers: `%s`, `%d`, `%.2f`, `%05d`,
  `%x`, multi-value tuple, `%%`, default `%f`, `%.f`, `%-05d`, integer modulo
- Generated V code compiles and produces output matching Python runtime